### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mirzayounus40/251b76ae-8418-4a41-a82a-d2cf86ad6b56/47d5108e-01f9-4cab-8e3a-b5d526aa66f6/_apis/work/boardbadge/310563fe-d98b-4a2d-a8fb-207a9d7197ee)](https://dev.azure.com/mirzayounus40/251b76ae-8418-4a41-a82a-d2cf86ad6b56/_boards/board/t/47d5108e-01f9-4cab-8e3a-b5d526aa66f6/Microsoft.RequirementCategory)
 <h3>
 Hi, this is Mirza. The world of computers is crazy!
 </h3>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mirzayounus40/251b76ae-8418-4a41-a82a-d2cf86ad6b56/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.